### PR TITLE
Untitled

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,8 +1,8 @@
 #Project properties
-#Thu Mar 17 18:41:56 CET 2011
+#Fri Mar 18 21:42:36 CET 2011
 project.organization=com.github.philcali
 project.name=sbt-lwjgl-plugin
 sbt.version=0.7.4
-project.version=2.0.2
+project.version=2.0.3
 build.scala.versions=2.8.1 2.8.0
 project.initialize=false


### PR DESCRIPTION
I've turned the native copying into its own task and made it depending on copy-resources, so it is called at compile and run time. And we have a clean-lwjgl task now to get rid of the natives while debugging.
