### PR TITLE
Fix for macosx directory structure

### DIFF
--- a/src/main/scala/LWJGLPlugin.scala
+++ b/src/main/scala/LWJGLPlugin.scala
@@ -103,7 +103,7 @@ object LWJGLPlugin extends Plugin {
   // Helper methods 
   def defineOs = System.getProperty("os.name").toLowerCase.take(3).toString match {
     case "lin" => ("linux", "so")
-    case "mac" | "dar" => ("osx", "lib")
+    case "mac" | "dar" => ("macosx", "lib")
     case "win" => ("windows", "dll")
     case "sun" => ("solaris", "so")
     case _ => ("unknown", "")
@@ -168,7 +168,7 @@ object LWJGLPlugin extends Plugin {
     cleanFiles <+= copyDir,
 
     fork := true,
-    javaOptions <+= (copyDir, lwjgl.os) { (dir, os) => 
+    javaOptions <+= (copyDir, lwjgl.os).map{ (dir, os) => 
       "-Djava.library.path=%s".format(dir / os._1)
     }
   )


### PR DESCRIPTION
This fixes the directory structure change on macosx, I also had to change the javaOptions to use map as apply was no longer compiling when using sbt 0.12.  If I need to fix/cleanup anything let me know, don't have a lot of experience with plugin development on sbt.
