### PR TITLE
The lwjgl-platform natives in Maven are called osx, not macosx

### DIFF
--- a/src/main/scala/LWJGLPlugin.scala
+++ b/src/main/scala/LWJGLPlugin.scala
@@ -110,7 +110,7 @@ object LWJGLPlugin extends Plugin {
   // Helper methods 
   def defineOs = System.getProperty("os.name").toLowerCase.take(3).toString match {
     case "lin" => ("linux", "so")
-    case "mac" | "dar" => ("macosx", "lib")
+    case "mac" | "dar" => ("osx", "lib")
     case "win" => ("windows", "dll")
     case "sun" => ("solaris", "so")
     case _ => ("unknown", "")


### PR DESCRIPTION
According to http://repo1.maven.org/maven2/org/lwjgl/lwjgl/lwjgl-platform/ all the current versions have `osx` in the name instead of `macosx`. This prevents the plugin from working on OSX.
